### PR TITLE
Geoip endpoint

### DIFF
--- a/lib/hnscan.js
+++ b/lib/hnscan.js
@@ -456,7 +456,7 @@ class Hnscan extends EventEmitter {
     return [peers, total];
   }
 
-  async getAllPeerAddresses(offset = 0) {
+  async getPeersLocation(offset = 0) {
     let peers = [];
 
     for (let peer = this.node.pool.peers.head(); peer; peer = peer.next) {
@@ -468,21 +468,12 @@ class Hnscan extends EventEmitter {
       peer.getName();
 
       // Separate addr hash and ip
-      let ip = peer.fullname().split("@")[1];
-
-      // Check for IPv6 and remove brackets
-      if (ip.includes("[") || ip.includes("]")) {
-        ip = ip.replace(/[\[\]']+/g, "");
-      }
-
-      // Remove trailing port numbers
-      ip = ip.substring(0, ip.length - 6);
+      // let ip = peer.fullname().split("@")[1];
+      let ip = peer.address.host;
 
       // GeoIP information
       peers.push(geoip.lookup(ip));
     }
-
-    // console.log(peers);
 
     return [peers];
   }

--- a/lib/hnscan.js
+++ b/lib/hnscan.js
@@ -19,6 +19,7 @@ const { Lock } = require("bmutex");
 const bio = require("bufio");
 const blake2b = require("bcrypto/lib/blake2b");
 const rules = require("hsd/lib/covenants/rules");
+const geoip = require("geoip-lite");
 
 /**
  * Hnscan
@@ -453,6 +454,37 @@ class Hnscan extends EventEmitter {
     peers = peers.slice(offset, offset + limit);
 
     return [peers, total];
+  }
+
+  async getAllPeerAddresses(offset = 0) {
+    let peers = [];
+
+    for (let peer = this.node.pool.peers.head(); peer; peer = peer.next) {
+      const hashes = [];
+
+      for (const hash in peer.blockMap.keys())
+        hashes.push(hash.toString("hex"));
+
+      peer.getName();
+
+      // Separate addr hash and ip
+      let ip = peer.fullname().split("@")[1];
+
+      // Check for IPv6 and remove brackets
+      if (ip.includes("[") || ip.includes("]")) {
+        ip = ip.replace(/[\[\]']+/g, "");
+      }
+
+      // Remove trailing port numbers
+      ip = ip.substring(0, ip.length - 6);
+
+      // GeoIP information
+      peers.push(geoip.lookup(ip));
+    }
+
+    // console.log(peers);
+
+    return [peers];
   }
 
   /**

--- a/lib/http.js
+++ b/lib/http.js
@@ -22,6 +22,7 @@ const rules = require("hsd/lib/covenants/rules");
 const Amount = require("hsd/lib/ui/amount");
 const NameState = require("hsd/lib/covenants/namestate");
 const pkg = require("hsd").pkg;
+const geoip = require("geoip-lite");
 
 const { Address, TX } = require("hsd");
 
@@ -429,43 +430,10 @@ class HTTP extends Server {
 
     //@todo allow for filtering of peers by services, etc.
     this.get("/mapdata", async (req, res) => {
-      // const valid = Validator.fromRequest(req);
-      // enforce(limit <= 50, "Too many names requested. Max of 50.");
-      // const [peers, total] = await this.hnscan.getPeers(offset, limit);
-      const data = [
-        {
-          title: "Vienna",
-          latitude: 48.2092,
-          longitude: 16.3728
-        },
-        {
-          title: "Minsk",
-          latitude: 53.9678,
-          longitude: 27.5766
-        },
-        {
-          title: "Brussels",
-          latitude: 50.8371,
-          longitude: 4.3676
-        },
-        {
-          title: "Sarajevo",
-          latitude: 43.8608,
-          longitude: 18.4214
-        },
-        {
-          title: "Sofia",
-          latitude: 42.7105,
-          longitude: 23.3238
-        },
-        {
-          title: "Zagreb",
-          latitude: 45.815,
-          longitude: 15.9785
-        }
-      ];
+      const [peers] = await this.hnscan.getAllPeerAddresses();
+      const data = peers;
 
-      res.json(200, { data });
+      res.json(200, { data: data });
     });
 
     /*

--- a/lib/http.js
+++ b/lib/http.js
@@ -430,8 +430,16 @@ class HTTP extends Server {
 
     //@todo allow for filtering of peers by services, etc.
     this.get("/mapdata", async (req, res) => {
-      const [peers] = await this.hnscan.getAllPeerAddresses();
-      const data = peers;
+      const [peers] = await this.hnscan.getPeersLocation();
+      const data = [];
+
+      for (let i = 0; i < peers.length; i++) {
+        data.push({
+          latitude: peers[i].ll[0],
+          longitude: peers[i].ll[1],
+          title: peers[i].city
+        });
+      }
 
       res.json(200, { data: data });
     });

--- a/lib/http.js
+++ b/lib/http.js
@@ -427,6 +427,47 @@ class HTTP extends Server {
       });
     });
 
+    //@todo allow for filtering of peers by services, etc.
+    this.get("/mapdata", async (req, res) => {
+      // const valid = Validator.fromRequest(req);
+      // enforce(limit <= 50, "Too many names requested. Max of 50.");
+      // const [peers, total] = await this.hnscan.getPeers(offset, limit);
+      const data = [
+        {
+          title: "Vienna",
+          latitude: 48.2092,
+          longitude: 16.3728
+        },
+        {
+          title: "Minsk",
+          latitude: 53.9678,
+          longitude: 27.5766
+        },
+        {
+          title: "Brussels",
+          latitude: 50.8371,
+          longitude: 4.3676
+        },
+        {
+          title: "Sarajevo",
+          latitude: 43.8608,
+          longitude: 18.4214
+        },
+        {
+          title: "Sofia",
+          latitude: 42.7105,
+          longitude: 23.3238
+        },
+        {
+          title: "Zagreb",
+          latitude: 45.815,
+          longitude: 15.9785
+        }
+      ];
+
+      res.json(200, { data });
+    });
+
     /*
      *
      * Address HTTP Functions

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bufio": "^1.0.3",
     "bval": "^0.1.4",
     "bweb": "^0.1.4",
+    "geoip-lite": "^1.3.8",
     "hsd": "github:handshake-org/hsd",
     "path": "^0.12.7"
   }


### PR DESCRIPTION
Adding in an http endpoint to send the user the geolocation data based on the handshake node ip address. This is useful for building out the map on https://hnscan.com/peers