### PR TITLE
chore: use correct mtime for name history

### DIFF
--- a/lib/hnscan.js
+++ b/lib/hnscan.js
@@ -733,7 +733,7 @@ class Hnscan extends EventEmitter {
               newtx.action = "Renew";
             }
 
-            newtx.time = tx.mtime;
+            newtx.time = meta.mtime;
             newtx.height = list[i].height;
             newtx.txid = list[i].tx_hash;
             newtx.index = j;


### PR DESCRIPTION
time was not being shown correctly on hnscan for name history. This sets the time correctly. 